### PR TITLE
Updated SOF definitions and added new types

### DIFF
--- a/black-classes/eve.js
+++ b/black-classes/eve.js
@@ -124,7 +124,7 @@ export default {
     maxSpeed: r.float,
     noiseScale: r.float,
     noiseScaleCurve: r.object,
-    rotationAroundParent: r.vector4,
+    rotationAroundParent: r.quaternion,
     translationFromParent: r.float,
     yaw: r.float,
     zoomCurve: r.object
@@ -144,7 +144,7 @@ export default {
     effect: r.object,
     name: r.string,
     preTesselationLevel: r.uint,
-    rotation: r.vector4,
+    rotation: r.quaternion,
     scaling: r.vector3,
     translation: r.vector3
   },
@@ -155,7 +155,7 @@ export default {
     controllers: r.array,
     display: r.boolean,
     displayFilter: r.object,
-    localTransform: r.matrix,
+    localTransform: r.matrix4,
     name: r.string,
     curveSets: r.array,
     hideOnLowQuality: r.boolean,
@@ -163,7 +163,7 @@ export default {
     lights: r.array,
     observers: r.array,
     objects: r.array,
-    rotation: r.vector4,
+    rotation: r.quaternion,
     scaling: r.vector3,
     staticTransform: r.boolean,
     transformModifiers: r.array,
@@ -192,9 +192,9 @@ export default {
     localExplosionInterval: r.float,
     localExplosionIntervalFactor: r.float,
     localExplosionShared: r.object,
-    localTransform: r.matrix,
+    localTransform: r.matrix4,
     name: r.string,
-    rotation: r.vector4,
+    rotation: r.quaternion,
     scaling: r.vector3
   },
 
@@ -205,20 +205,20 @@ export default {
   "EveChildInstanceContainer" : {
     source: r.object,
     scaling: r.vector3,
-    localTransform: r.matrix
+    localTransform: r.matrix4
   },
 
   "EveChildLineSet": {
     name: r.string,
     additiveBatches: r.boolean,
-    animColor: r.vector4,
-    baseColor: r.vector4,
+    animColor: r.color,
+    baseColor: r.color,
     brightness: r.float,
     display: r.boolean,
     lines: r.array,
     lineSet: r.object,
     minScreenSize: r.float,
-    rotation: r.vector4,
+    rotation: r.quaternion,
     scrollSpeed: r.float,
     translation: r.vector3,
   },
@@ -228,17 +228,17 @@ export default {
     linkStrengthCurves: r.array,
     mesh: r.object,
     name: r.string,
-    rotation: r.vector4
+    rotation: r.quaternion
   },
 
   "EveChildMesh": {
     display: r.boolean,
-    localTransform: r.matrix,
+    localTransform: r.matrix4,
     lowestLodVisible: r.uint,
     mesh: r.object,
     minScreenSize: r.float,
     name: r.string,
-    rotation: r.vector4,
+    rotation: r.quaternion,
     scaling: r.vector3,
     sortValueOffset: r.float,
     staticTransform: r.boolean,
@@ -265,14 +265,14 @@ export default {
 
   "EveChildParticleSystem": {
     display: r.boolean,
-    localTransform: r.matrix,
+    localTransform: r.matrix4,
     lodSphereRadius: r.float,
     mesh: r.object,
     minScreenSize: r.float,
     name: r.string,
     particleEmitters: r.array,
     particleSystems: r.array,
-    rotation: r.vector4,
+    rotation: r.quaternion,
     scaling: r.vector3,
     translation: r.vector3,
     transformModifiers: r.array,
@@ -300,7 +300,7 @@ export default {
   },
 
   "EveChildModifierSRT": {
-    rotation: r.vector4,
+    rotation: r.quaternion,
     scaling: r.vector3,
     translation: r.vector3,
   },
@@ -313,10 +313,10 @@ export default {
     brightness: r.float,
     color: r.color,
     effect: r.object,
-    localTransform: r.matrix,
+    localTransform: r.matrix4,
     minScreenSize: r.float,
     name: r.string,
-    rotation: r.vector4,
+    rotation: r.quaternion,
     scaling: r.vector3,
     translation: r.vector3,
   },
@@ -345,7 +345,7 @@ export default {
   "EveCustomMask": {
     materialIndex: r.byte,
     position: r.vector3,
-    rotation: r.vector4,
+    rotation: r.quaternion,
     scaling: r.vector3,
     targetMaterials: r.vector4,
   },
@@ -361,7 +361,7 @@ export default {
     lights: r.array,
     name: r.string,
     observers: r.array,
-    rotation: r.vector4,
+    rotation: r.quaternion,
     rotationCurve: r.object,
     scaling: r.vector3,
     secondaryLightingEmissiveColor: r.color,
@@ -399,7 +399,7 @@ export default {
 
   "EveLocator2": {
     name: r.string,
-    transform: r.matrix,
+    transform: r.matrix4,
   },
 
   "EveMeshOverlayEffect": {
@@ -479,7 +479,7 @@ export default {
     maskAtlasID: r.uint,
     name: r.string,
     position: r.vector3,
-    rotation: r.vector4,
+    rotation: r.quaternion,
     scaling: r.vector3,
   },
     
@@ -493,7 +493,7 @@ export default {
     name: r.string,
     observers: r.array,
     position: r.vector3,
-    rotation: r.vector4,
+    rotation: r.quaternion,
     rotationCurve: r.object,
     scaling: r.vector3,
     sortValueMultiplier: r.float,
@@ -549,7 +549,7 @@ export default {
     decalEffect: r.object,
     name: r.string,
     position: r.vector3,
-    rotation: r.vector4,
+    rotation: r.quaternion,
     scaling: r.vector3,
     indexBuffer: r.indexBuffer
   },
@@ -564,7 +564,7 @@ export default {
     envMapResPath: r.path,
     envMap1ResPath: r.path,
     envMap2ResPath: r.path,
-    envMapRotation: r.vector4,
+    envMapRotation: r.quaternion,
     externalParameters: r.array,
     fogColor: r.color,
     fogStart: r.float,
@@ -580,7 +580,7 @@ export default {
     shadowThreshold: r.float,
     shLightingManager: r.object,
     sunDiffuseColor: r.color,
-    sunDiffuseColorWithDynamicLights: r.vector4,
+    sunDiffuseColorWithDynamicLights: r.color,
     sunDirection: r.vector3,
     useSunDiffuseColorWithDynamicLights: r.boolean
   },
@@ -614,7 +614,7 @@ export default {
     name: r.string,
     spriteColor: r.color,
     spriteScale: r.vector3,
-    transform: r.matrix
+    transform: r.matrix4
   },
     
   "EveSpriteSet": {
@@ -708,7 +708,7 @@ export default {
     overrideBoundsMin: r.vector3,
     particleEmitters: r.array,
     particleSystems: r.array,
-    rotation: r.vector4,
+    rotation: r.quaternion,
     scaling: r.vector3,
     sortValueMultiplier: r.float,
     translation: r.vector3,

--- a/black-classes/sof.js
+++ b/black-classes/sof.js
@@ -24,7 +24,6 @@ class Instance {
   }
 }
 
-
 export default {
 
   "EveSOFData": {
@@ -71,20 +70,20 @@ export default {
   },
 
   "EveSOFDataBooster": {
-    glowColor: r.vector4,
+    glowColor: r.color,
     glowScale: r.float,
     gradient0ResPath: r.path,
     gradient1ResPath: r.path,
-    haloColor: r.vector4,
+    haloColor: r.color,
     haloScaleX: r.float,
     haloScaleY: r.float,
     lightFlickerAmplitude: r.float,
-    lightFlickerColor: r.vector4,
+    lightFlickerColor: r.color,
     lightFlickerFrequency: r.float,
     lightFlickerRadius: r.float,
-    lightColor: r.vector4,
+    lightColor: r.color,
     lightRadius: r.float,
-    lightWarpColor: r.vector4,
+    lightWarpColor: r.color,
     lightWarpRadius: r.float,
     shape0: r.object,
     shape1: r.object,
@@ -93,17 +92,17 @@ export default {
     shapeAtlasResPath: r.path,
     shapeAtlasWidth: r.uint,
     symHaloScale: r.float,
-    trailColor: r.vector4,
+    trailColor: r.color,
     trailSize: r.vector4,
     volumetric: r.boolean,
-    warpGlowColor: r.vector4,
-    warpHalpColor: r.vector4,
+    warpGlowColor: r.color,
+    warpHalpColor: r.color,
     warpShape0: r.object,
     warpShape1: r.object
   },
 
   "EveSOFDataBoosterShape": {
-    color: r.vector4,
+    color: r.color,
     noiseFunction: r.float,
     noiseSpeed: r.float,
     noiseAmplitureStart: r.vector4,
@@ -140,28 +139,28 @@ export default {
   },
 
   "EveSOFDataFactionColorSet": {
-    Black: r.vector4,
-    Blue: r.vector4,
-    Booster: r.vector4,
-    Cyan: r.vector4,
-    Darkhull: r.vector4,
-    Fire: r.vector4,
-    Glass: r.vector4,
-    Green: r.vector4,
-    Hull: r.vector4,
-    Killmark: r.vector4,
-    Orange: r.vector4,
-    Primary: r.vector4,
-    PrimaryLight: r.vector4,
-    Reactor: r.vector4,
-    Red: r.vector4,
-    Secondary: r.vector4,
-    SecondaryLight: r.vector4,
-    Tertiary: r.vector4,
-    TertiaryLight: r.vector4,
-    White: r.vector4,
-    WhiteLight: r.vector4,
-    Yellow: r.vector4
+    Black: r.color,
+    Blue: r.color,
+    Booster: r.color,
+    Cyan: r.color,
+    Darkhull: r.color,
+    Fire: r.color,
+    Glass: r.color,
+    Green: r.color,
+    Hull: r.color,
+    Killmark: r.color,
+    Orange: r.color,
+    Primary: r.color,
+    PrimaryLight: r.color,
+    Reactor: r.color,
+    Red: r.color,
+    Secondary: r.color,
+    SecondaryLight: r.color,
+    Tertiary: r.color,
+    TertiaryLight: r.color,
+    White: r.color,
+    WhiteLight: r.color,
+    Yellow: r.color
   },
 
   "EveSOFDataFactionDecal": {
@@ -186,7 +185,7 @@ export default {
   },
 
   "EveSOFDataFactionPlaneSet": {
-    color: r.vector4,
+    color: r.color,
     groupIndex: r.uint,
     name: r.string
   },
@@ -204,6 +203,7 @@ export default {
     damage: r.object,
     genericWreckMaterial: r.object,
     hullAreas: r.array,
+    hullCategories: r.array,
     hullDamage: r.object,
     materialPrefixes: r.array,
     patternMaterialPrefixes: r.array,
@@ -218,10 +218,10 @@ export default {
 
   "EveSOFDataGenericDamage": {
     armorParticleAngle: r.float,
-    armorParticleColor0: r.vector4,
-    armorParticleColor1: r.vector4,
-    armorParticleColor2: r.vector4,
-    armorParticleColor3: r.vector4,
+    armorParticleColor0: r.color,
+    armorParticleColor1: r.color,
+    armorParticleColor2: r.color,
+    armorParticleColor3: r.color,
     armorParticleDrag: r.float,
     armorParticleMinMaxLifeTime: r.vector2,
     armorParticleMinMaxSpeed: r.vector2,
@@ -250,9 +250,9 @@ export default {
 
   "EveSOFDataGenericHullDamage": {
     hullParticleAngle: r.float,
-    hullParticleColor0: r.vector4,
-    hullParticleColor1: r.vector4,
-    hullParticleColor2: r.vector4,
+    hullParticleColor0: r.color,
+    hullParticleColor1: r.color,
+    hullParticleColor2: r.color,
     hullParticleColorMidpoint: r.float,
     hullParticleDrag: r.float,
     hullParticleMinMaxLifeTime: r.vector2,
@@ -343,12 +343,12 @@ export default {
   "EveSOFDataHullAnimation": {
     endRate: r.float,
     endRotationTime: r.float,
-    endRotationValue: r.vector4,
+    endRotationValue: r.quaternion,
     id: r.uint,
     name: r.string,
     startRate: r.float,
     startRotationTime: r.float,
-    startRotationValue: r.vector4
+    startRotationValue: r.quaternion
   },
 
   "EveSOFDataHullArea": {
@@ -370,7 +370,7 @@ export default {
     lightOverride: r.object,
     name: r.string,
     position: r.vector3,
-    rotation: r.vector4,
+    rotation: r.quaternion,
     scaling: r.vector3,
     usage: r.uint
   },
@@ -391,7 +391,7 @@ export default {
     functionality: r.vector4,
     hasTrail: r.boolean,
     lightScale: r.float,
-    transform: r.matrix
+    transform: r.matrix4
   },
 
   "EveSOFDataHullChild": {
@@ -400,7 +400,7 @@ export default {
     lowestLodVisible: r.uint,
     name: r.string,
     redFilePath: r.string,
-    rotation: r.vector4,
+    rotation: r.quaternion,
     scaling: r.vector3,
     translation: r.vector3
   },
@@ -424,7 +424,7 @@ export default {
     meshIndex: r.uint,
     parameters: r.array,
     position: r.vector3,
-    rotation: r.vector4,
+    rotation: r.quaternion,
     scaling: r.vector3,
     textures: r.array,
     usage: r.uint,
@@ -434,16 +434,18 @@ export default {
   "EveSOFDataHullHazeSet": {
     items: r.array,
     name: r.string,
+    skinned: r.boolean,
     visibilityGroup: r.string
   },
 
   "EveSOFDataHullHazeSetItem": {
+    boneIndex: r.uint,
     boosterGainInfluence: r.boolean,
     colorType: r.uint,
     hazeBrightness: r.float,
     hazeFalloff: r.float,
     position: r.vector3,
-    rotation: r.vector4,
+    rotation: r.quaternion,
     scaling: r.vector3,
     sourceBrightness: r.float,
     sourceSize: r.float
@@ -460,7 +462,7 @@ export default {
     boneIndex: r.uint,
     brightness: r.float,
     innerRadius: r.float,
-    lightColor: r.vector4,
+    lightColor: r.color,
     noiseAmplitude: r.float,
     noiseFrequency: r.float,
     noiseOctaves: r.float,
@@ -490,12 +492,12 @@ export default {
     outerAngle: r.float,
     position: r.vector3,
     radius: r.float,
-    rotation: r.vector4
+    rotation: r.quaternion
   },
 
   "EveSOFDataHullLocator": {
     name: r.string,
-    transform: r.matrix
+    transform: r.matrix4
   },
 
   "EveSOFDataHullLocatorSet": {
@@ -520,7 +522,7 @@ export default {
     blinkPhase: r.float,
     blinkMode: r.uint,
     boneIndex: r.uint,
-    color: r.vector4,
+    color: r.color,
     dutyCycle: r.float,
     groupIndex: r.uint,
     layer1Scroll: r.vector4,
@@ -530,7 +532,7 @@ export default {
     maskMapAtlasIndex: r.uint,
     position: r.vector3,
     rate: r.float,
-    rotation: r.vector4,
+    rotation: r.quaternion,
     scaling: r.vector3
   },
 
@@ -551,13 +553,14 @@ export default {
     groupIndex: r.uint,
     spriteScale: r.vector3,
     spriteIntensity: r.float,
-    transform: r.matrix
+    transform: r.matrix4
   },
 
   "EveSOFDataHullSoundEmitter": {
     name: r.string,
     position: r.vector3,
-    prefix: r.string
+    prefix: r.string,
+    rotation: r.quaternion
   },
 
   "EveSOFDataHullSpriteLineSet": {
@@ -580,7 +583,7 @@ export default {
     maxScale: r.float,
     minScale: r.float,
     position: r.vector3,
-    rotation: r.vector4,
+    rotation: r.quaternion,
     scaling: r.vector3,
     spacing: r.float
   },
@@ -606,6 +609,7 @@ export default {
   },
 
   "EveSOFDataInstancedMesh": {
+    displayModifier: r.uint,
     geometryResPath: r.path,
     instances: r.structList(Instance),
     lowestLodVisible: r.uint,
@@ -652,7 +656,7 @@ export default {
   "EveSOFDataPatternTransform": {
     isMirrored: r.boolean,
     position: r.vector3,
-    rotation: r.vector4,
+    rotation: r.quaternion,
     scaling: r.vector3
   },
 
@@ -670,11 +674,11 @@ export default {
   },
 
   "EveSOFDataFactionSpotlightSet": {
-    coneColor: r.vector4,
-    flareColor: r.vector4,
+    coneColor: r.color,
+    flareColor: r.color,
     groupIndex: r.uint,
     name: r.string,
-    spriteColor: r.vector4
+    spriteColor: r.color
   },
 
   "EveSOFDataTexture": {
@@ -685,8 +689,12 @@ export default {
   "EveSOFDataTransform": {
     boneIndex: r.uint,
     position: r.vector3,
-    rotation: r.vector4,
+    rotation: r.quaternion,
     scaling: r.vector3
+  },
+
+  "EveSOFDataVisibilityGroup" :{
+    name: r.string
   }
 
 }

--- a/black-classes/tr2.js
+++ b/black-classes/tr2.js
@@ -498,6 +498,7 @@ export default {
     depthAreas: r.array,
     distortionAreas: r.array,
     geometryRes: r.object,
+    name: r.string,
     opaqueAreas: r.array,
     pickableAreas: r.array,
     transparentAreas: r.array

--- a/black-classes/tr2.js
+++ b/black-classes/tr2.js
@@ -155,7 +155,7 @@ export default {
     minTheta: r.float,
     parentVelocityFactor: r.float,
     position: r.vector3,
-    rotation: r.vector4
+    rotation: r.quaternion
   },
 
   "Tr2PlaneConstraint": {
@@ -303,10 +303,10 @@ export default {
     angle: r.float,
     attractorPosition: r.vector3,
     attractorStrength: r.float,
-    color0: r.vector4,
-    color1: r.vector4,
-    color2: r.vector4,
-    color3: r.vector4,
+    color0: r.color,
+    color1: r.color,
+    color2: r.color,
+    color3: r.color,
     colorMidpoint: r.float,
     continuousEmitter: r.boolean,
     direction: r.vector3,
@@ -339,10 +339,10 @@ export default {
     angle: r.float,
     attractorPosition: r.vector3,
     attractorStrength: r.float,
-    color0: r.vector4,
-    color1: r.vector4,
-    color2: r.vector4,
-    color3: r.vector4,
+    color0: r.color,
+    color1: r.color,
+    color2: r.color,
+    color3: r.color,
     colorMidpoint: r.float,
     continuousEmitter: r.boolean,
     direction: r.vector3,
@@ -415,7 +415,7 @@ export default {
   },
 
   "Tr2InteriorLightSource": {
-    color: r.vector4,
+    color: r.color,
     coneAlphaInner: r.float,
     coneAlphaOuter: r.float,
     coneDirection: r.vector3,
@@ -450,7 +450,7 @@ export default {
     name: r.string,
     boneIndex: r.uint,
     brightness: r.float,
-    color: r.vector4,
+    color: r.color,
     innerRadius: r.float,
     noiseAmplitude: r.float,
     noiseFrequency: r.float,
@@ -516,13 +516,13 @@ export default {
 
   "Tr2Matrix4Parameter": {
     name: r.string,
-    value: r.matrix
+    value: r.matrix4
   },
 
   "Tr2SpotLight" : {
     name: r.string,
     brightness: r.float,
-    color: r.vector4,
+    color: r.color,
     innerAngle: r.float,
     innerRadius: r.float,
     noiseAmplitude: r.float,
@@ -530,7 +530,7 @@ export default {
     outerAngle: r.float,
     position: r.vector3,
     radius: r.float,
-    rotation: r.vector4
+    rotation: r.quaternion
   },
 
   "Tr2StaticEmitter": {

--- a/black-classes/tri.js
+++ b/black-classes/tri.js
@@ -5,7 +5,7 @@ export default {
   "TriColorSequencer": {
     functions: r.array,
     name: r.string,
-    value: r.vector4
+    value: r.color
   },
 
   "TriCurveSet": {
@@ -82,7 +82,7 @@ export default {
 
   "TriTransformParameter": {
     name: r.string,
-    rotation: r.vector4
+    rotation: r.quaternion
   },
 
   "TriValueBinding": {

--- a/black-readers.js
+++ b/black-readers.js
@@ -101,15 +101,11 @@ export function byte(reader) {
   return reader.readU8()
 }
 
-export function color(reader) {
-  return [reader.readF32(), reader.readF32(), reader.readF32(), reader.readF32()]
-}
-
 export function float(reader) {
   return reader.readF32()
 }
 
-export function matrix(reader) {
+export function matrix4(reader) {
   var buffer = new ArrayBuffer(64)
 
   return [
@@ -159,6 +155,7 @@ export function object(reader, id = null) {
 
     if (properties.has(propertyName)) {
       try {
+
         let propertyReader = properties.get(propertyName)
 
         if (propertyReader.complexReader) {
@@ -179,8 +176,7 @@ export function object(reader, id = null) {
           debugContext.property(propertyName, value)
         }
       } catch (e) {
-        throw e
-
+        //throw e;
         if (e instanceof UnknownPropertyError) {
           throw e
         } else {
@@ -247,6 +243,28 @@ export function vector4(reader, result = new Float32Array(4)) {
   result[2] = reader.readF32()
   result[3] = reader.readF32()
   return result
+}
+
+export function color(reader, result = new Float32Array(4)) {
+  result[0] = reader.readF32()
+  result[1] = reader.readF32()
+  result[2] = reader.readF32()
+  result[3] = reader.readF32()
+  if (typeof reader.context.color == "function") {
+    return reader.context.color(result)
+  }
+  return result;
+}
+
+export function quaternion(reader, result = new Float32Array(4)) {
+  result[0] = reader.readF32()
+  result[1] = reader.readF32()
+  result[2] = reader.readF32()
+  result[3] = reader.readF32()
+  if (typeof reader.context.quaternion == "function") {
+    return reader.context.quaternion(result);
+  }
+  return result;
 }
 
 // Complicated


### PR DESCRIPTION
- Added explicit `quaternion` type which can be transformed with an optional `context.quaternion` handler (e.g. to XYZ eulers)
- `color` types can now be transformed with an optional `context.color` handler (e.g. to RGBA)
- Updated all properties to correctly use `color` and `quaternion` types
- Added missing SOF definitions
- Renamed `matrix` to `matrix4`
- Tested changes with latest space object factory (data.black)