### PR TITLE
Spring cleaning

### DIFF
--- a/black-classes/eve.js
+++ b/black-classes/eve.js
@@ -1,5 +1,4 @@
 import * as r from "../black-readers.js"
-import { typeSymbol } from "../black";
 
 class Locator {
   constructor(position, direction) {

--- a/black-classes/sof.js
+++ b/black-classes/sof.js
@@ -418,7 +418,8 @@ export default {
   "EveSOFDataHullDecalSetItem": {
     name: r.string,
     boneIndex: r.uint,
-    indexBuffer: r.indexBuffer,
+    indexBuffer: r.array,
+    indexBuffers: r.array,
     glowColorType: r.uint,
     logoType: r.uint,
     meshIndex: r.uint,
@@ -429,6 +430,15 @@ export default {
     textures: r.array,
     usage: r.uint,
     visibilityGroup: r.string
+  },
+
+  "EveSOFDataDecalIndexBuffer" : {
+      indexBuffer: r => {
+        const count = r.readU32() / 4;
+        const indexBuffer = new Uint32Array(count);
+        for (let i = 0; i < count; i++) indexBuffer[i] = r.readU32();
+        return indexBuffer;
+      }
   },
 
   "EveSOFDataHullHazeSet": {

--- a/black.js
+++ b/black.js
@@ -85,8 +85,6 @@ export function read(view, context, debugContext = nullDebugContext) {
     debugContext.log(`${i}: ${strings[i]}`)
   }
 
-  let result = {}
-
   let commentReader = reader.readBinaryReader(reader.readU32())
   let commentCount = commentReader.readU16()
   let comments = []

--- a/package.json
+++ b/package.json
@@ -4,12 +4,14 @@
   "description": "Reader for .black files from EVE: Online",
   "main": "index.js",
   "module": "black.js",
+  "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "aurora",
   "license": "MIT",
   "dependencies": {
-    "esm": "^3.0.84"
+    "json-stream-stringify": "^3.0.1",
+    "ora": "^6.1.2"
   }
 }

--- a/runner.js
+++ b/runner.js
@@ -1,35 +1,47 @@
 #!/usr/bin/env node
+import * as black from "./black.js";
+import * as dough from "./dough.js";
+import { stat, readdir, readFile,  mkdir, writeFile  } from "fs/promises";
+import path from "path";
 
-require = require("esm")(module)
-
-let black = require("./black.js")
-let dough = require("./dough.js")
-let fs = require("fs")
-let path = require("path")
 
 let args = process.argv.slice(2)
 let context = new black.Context()
 let debugContext = black.nullDebugContext
 // let debugContext = new black.VerboseDebugContext(console)
 
-function processPath(p, output) {
-  if (fs.statSync(p).isDirectory()) {
-    fs.readdirSync(p).forEach((file) => { processPath(path.join(p, file), path.join(output, file.replace(/\.black$/, ".dough"))) })
+async function processPath(p, output) {
+  const stats = await stat(p);
+  if (stats.isDirectory()) {
+    const files = await readdir(p);
+    for (let i = 0; i < files.length; i++) {
+      await processPath(path.join(p, files[i]), path.join(output, files[i].replace(/\.black$/, ".dough")))
+    }
   } else {
-    if (path.extname(p) == ".black") {
-      let buffer = fs.readFileSync(p)
+    if (path.extname(p) === ".black") {
+      let buffer = await readFile(p)
       let view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength)
-
-      let result = dough.stringify(black.read(view, context, debugContext))
-
-      fs.mkdirSync(path.dirname(output), { recursive: true })
-      fs.writeFileSync(output, result)
-
+      let result = await dough.stringifyStream(black.read(view, context, debugContext),p)
+      await mkdir(path.dirname(output), {recursive: true})
+      await writeFile(output, result, 'utf-8')
       console.log("%s => %s", p, output)
     }
   }
 }
 
-for (let i = 0; i < args.length - 1; i++) {
-  processPath(args[i], args[args.length - 1])
+async function main() {
+  for (let i = 0; i < args.length - 1; i++) {
+    await processPath(args[i], args[args.length - 1])
+  }
 }
+
+main()
+    .then(() => process.exit(0))
+    .catch(err =>
+    {
+      console.error(err);
+      process.exit(1);
+    })
+
+
+


### PR DESCRIPTION
- Replaced JSON.stringify with JsonStreamStringify, so we can convert big objects like data.black
- Added a spinner, so you can tell your computer hasn't died converting those big files
- Removed ESM and changed the package to be a module
- Updated sync function calls to async (but we're still doing one file at a time atm)
- Updated EveSOFDataHullDecalSetItem and added EveSOFDataDecalIndexBuffer